### PR TITLE
Feat: Use SSL for Cassandra DB

### DIFF
--- a/src/feast_cassandra_online_store/cassandra_online_store.py
+++ b/src/feast_cassandra_online_store/cassandra_online_store.py
@@ -145,7 +145,7 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     """Explicit specification of the CQL protocol version used."""
 
     ssl: Optional[StrictBool] = False
-    """if CassandaDB uses ssl for ex CosmosDB"""
+    """if CassandaDB uses ssl ex: CosmosDB"""
 
     class CassandraLoadBalancingPolicy(FeastConfigBaseModel):
         """


### PR DESCRIPTION
This PR is to enable ssl for Cassandra DB Example use case usage of azure CosmosDB cassandra api

usage: 
```
project: feature_repo
registry: data/registry.db
provider: local
online_store:
    type: feast_cassandra_online_store.cassandra_online_store.CassandraOnlineStore
    hosts:
        - test.cassandra.cosmos.azure.com
    keyspace: uprofile
    ssl: true
    port: 10350        # optional
```